### PR TITLE
Feature: add support for short-id

### DIFF
--- a/main.py
+++ b/main.py
@@ -147,6 +147,10 @@ class MyHandler(blivedm.BaseHandler):
 async def reminder(room_ids: List[int]):
     handler = MyHandler()
     for room_id in room_ids:
+        live_room_info = get_live_room_info(room_id)
+        if live_room_info is None:
+            continue
+        room_id = live_room_info["room_id"]
         handler.add_room(room_id)
 
     clients = [blivedm.BLiveClient(room_id) for room_id in room_ids]


### PR DESCRIPTION
# 问题描述
- 在某些有短id的直播间使用会出现问题
- 例如[Asaki大人的直播间(732)](https://live.bilibili.com/732?broadcast_type=0&is_room_feed=1&spm_id_from=333.1387.to_liveroom.0.click&live_from=86002)

# 问题原因
`MyHandler` 中 `rooms` 字典的 key 是`room_id = 732`(short_id)，但实际的`room = self.rooms.get(client.room_id)`得到的是`room_id = 6154037`(room_id)，因此在 callback 中会找不到 `LiveRoom` 的实例。
从 `get_live_room_info(room_id)` 的 response 中也能看到：
```json
{
   "uid":194484313,
   "room_id":6154037,
   "short_id":732,
   "attention":1734210,
   "online":0,
   "is_portrait":false,
   "description":"",
   "live_status":2
}
```
# 解决办法
在实例化 `LiveRoom` 之前先请求一次 `get_live_room_info(room_id)` 拿到真正的 `room_id`
```diff
    for room_id in room_ids:
+      live_room_info = get_live_room_info(room_id)
+      if live_room_info is None:
+          continue
+      room_id = live_room_info["room_id"]
       handler.add_room(room_id)
```